### PR TITLE
Make the URLProvider interface more comprehensive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### Unreleased
 
+* Improve / extend the UrlProvider interface to cover customisation of more URLs and support single-action controllers.
+  Also means that all expected / generated URLs have changed so this is breaking for any links that have been produced
+  which will all now be invalid.
+
 ### v0.1.0 (2018-02-13)
 
 * First version, extracted from host project

--- a/src/Support/FixedUrlProviderStub.php
+++ b/src/Support/FixedUrlProviderStub.php
@@ -49,6 +49,11 @@ class FixedUrlProviderStub implements UrlProvider
         return $url;
     }
 
+    public function getLogoutUrl()
+    {
+        return '/logout';
+    }
+
     public function getRegisterVerifyEmailUrl($email = NULL)
     {
         $url = '/register-verify-email';

--- a/src/Support/FixedUrlProviderStub.php
+++ b/src/Support/FixedUrlProviderStub.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * @author    Andrew Coulton <andrew@ingenerator.com>
+ */
+
+namespace Ingenerator\Warden\Core\Support;
+
+use Ingenerator\Warden\Core\Entity\User;
+
+class FixedUrlProviderStub implements UrlProvider
+{
+    public function getAfterLoginUrl(User $user)
+    {
+        return '/after-login?'.http_build_query(['email' => $user->getEmail()]);
+    }
+
+    public function getAfterLogoutUrl()
+    {
+        return '/after-logout';
+    }
+
+    public function getAfterVerifyEmailSentUrl()
+    {
+        return '/after-verify-email-sent';
+    }
+
+    public function getCompletePasswordResetUrl(array $params)
+    {
+        return '/complete-password-reset?'.http_build_query($params);
+    }
+
+    public function getCompleteRegistrationUrl(array $params)
+    {
+        return '/complete-registration?'.http_build_query($params);
+    }
+
+    public function getDefaultUserHomeUrl(User $user)
+    {
+        return '/user-home?'.http_build_query(['email' => $user->getEmail()]);
+    }
+
+    public function getLoginUrl($email = NULL)
+    {
+        $url = '/login';
+        if ($email) {
+            $url .= '?'.http_build_query(['email' => $email]);
+        }
+
+        return $url;
+    }
+
+    public function getRegisterVerifyEmailUrl($email = NULL)
+    {
+        $url = '/register-verify-email';
+        if ($email) {
+            $url .= '?'.http_build_query(['email' => $email]);
+        }
+
+        return $url;
+    }
+
+}

--- a/src/Support/UrlProvider.php
+++ b/src/Support/UrlProvider.php
@@ -11,20 +11,103 @@ use Ingenerator\Warden\Core\Entity\User;
 
 interface UrlProvider
 {
-    public function getLoginUrl($email = NULL);
-
-    public function getCompletePasswordResetUrl(array $params);
-
-    public function getRegisterVerifyEmailUrl($email = NULL);
-
-    public function getCompleteRegistrationUrl(array $params);
-
-    public function getDefaultUserHomeUrl(User $user);
-
+    /**
+     * The URL this user will be taken to when they first complete a login,
+     * either by logging in with a password or through password reset etc.
+     *
+     * Commonly /profile
+     *
+     * @param User $user
+     *
+     * @return string
+     */
     public function getAfterLoginUrl(User $user);
 
+    /**
+     * The URL to take a user to once they have logged out
+     *
+     * Commonly /
+     *
+     * @return string
+     */
     public function getAfterLogoutUrl();
 
+    /**
+     * The URL to take a user to once we have successfully sent a "verify your email"
+     * link prior to registration. Note the user is not authenticated nor does it make
+     * sense to go back to register etc, since they have to go to their inbox now.
+     *
+     * Commonly / - could also be a site-specific dedicated success page
+     *
+     * @return string
+     */
     public function getAfterVerifyEmailSentUrl();
+
+    /**
+     * The signed URL a user will use to complete their password reset. This needs to be
+     * fully qualified e.g. with scheme and host as it will be rendered into their email
+     * link.
+     *
+     * Commonly /login/reset-password
+     *
+     * @param array $params the registration details and confirmation token
+     *
+     * @return string
+     */
+    public function getCompletePasswordResetUrl(array $params);
+
+    /**
+     * The signed URL a user will use to complete registration once they've verified their
+     * email. This needs to be fully qualified e.g. with scheme and host as it will be
+     * rendered into their email link.
+     *
+     * Commonly /register
+     *
+     * @param array $params the registration details and confirmation token
+     *
+     * @return string
+     */
+    public function getCompleteRegistrationUrl(array $params);
+
+    /**
+     * The default homepage for a user. This is generally used when for example they
+     * attempt to access a login / register / reset password page when they're already
+     * logged in.
+     *
+     * Commonly /profile
+     *
+     * @param User $user
+     *
+     * @return string
+     */
+    public function getDefaultUserHomeUrl(User $user);
+
+    /**
+     * The login page, optionally with an email address pre-filled (e.g. if redirecting from
+     * a registration attempt that failed because the user is already registered)
+     *
+     * Commonly /login
+     *
+     * @param string $email
+     *
+     * @return string
+     */
+    public function getLoginUrl($email = NULL);
+
+    /**
+     * @return string
+     */
+    public function getLogoutUrl();
+
+    /**
+     * The page to enter an email address and trigger verification ahead of doing a full
+     * registration. Optionally with email pre-filled e.g. after a login attempt that failed
+     * because the user is already registered.
+     *
+     * @param string $email
+     *
+     * @return string
+     */
+    public function getRegisterVerifyEmailUrl($email = NULL);
 
 }

--- a/src/Support/UrlProvider.php
+++ b/src/Support/UrlProvider.php
@@ -7,9 +7,24 @@
 namespace Ingenerator\Warden\Core\Support;
 
 
+use Ingenerator\Warden\Core\Entity\User;
+
 interface UrlProvider
 {
-    public function getLoginUrl();
-    public function getRegistrationUrl();
+    public function getLoginUrl($email = NULL);
+
+    public function getCompletePasswordResetUrl(array $params);
+
+    public function getRegisterVerifyEmailUrl($email = NULL);
+
+    public function getCompleteRegistrationUrl(array $params);
+
+    public function getDefaultUserHomeUrl(User $user);
+
+    public function getAfterLoginUrl(User $user);
+
+    public function getAfterLogoutUrl();
+
+    public function getAfterVerifyEmailSentUrl();
 
 }


### PR DESCRIPTION
And support separate URLs for every interaction exposed by Warden.
Obviously this interface can still return the same URL for every
action and differentiate by querystring if you really want to...