### PR TITLE
Handle login error when user email verification is not valid to send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### Unreleased
 
+* [Feature] Now explicitly returns instead of throwing if a login request causes an email verification,
+  and that verification fails because the email is invalid. This might happen because of temporary DNS
+  resolution errors at the server or the user's mail domain. Best handling of 
+  `LoginResponse::ERROR_EMAIL_VERIFICATION_FAILED` is likely to be to show a "temporary error" message.
 * [Feature] Can now trigger and complete email verification for inactive accounts, including that an
   activation is sent automatically on attempt to login to inactive account when the correct password 
   is used. Using the wrong password (or if the account has no password) will result in a password 

--- a/src/Interactor/LoginInteractor.php
+++ b/src/Interactor/LoginInteractor.php
@@ -95,6 +95,10 @@ class LoginInteractor
         $result  = $this->email_verification->execute($request);
         if ($result->isFailureCode(EmailVerificationResponse::ERROR_RATE_LIMITED)) {
             return LoginResponse::passwordIncorrectRateLimited($user, $result->canRetryAfter());
+
+        } elseif ($result->isFailureCode(EmailVerificationResponse::ERROR_DETAILS_INVALID)) {
+            return LoginResponse::emailFailed($user);
+
         } elseif ( ! $result->wasSuccessful()) {
             throw new \UnexpectedValueException(
                 'Password reset verification failed: '.$result->getFailureCode()
@@ -110,6 +114,10 @@ class LoginInteractor
         $result  = $this->email_verification->execute($request);
         if ($result->isFailureCode(EmailVerificationResponse::ERROR_RATE_LIMITED)) {
             return LoginResponse::notActiveRateLimited($user, $result->canRetryAfter());
+
+        } elseif ($result->isFailureCode(EmailVerificationResponse::ERROR_DETAILS_INVALID)) {
+            return LoginResponse::emailFailed($user);
+
         } elseif ( ! $result->wasSuccessful()) {
             throw new \UnexpectedValueException(
                 'Activation send failed: '.$result->getFailureCode()

--- a/src/Interactor/LoginResponse.php
+++ b/src/Interactor/LoginResponse.php
@@ -12,6 +12,7 @@ use Ingenerator\Warden\Core\Entity\User;
 class LoginResponse extends AbstractResponse
 {
 
+    const ERROR_EMAIL_VERIFICATION_FAILED = 'email-verification-failed';
     const ERROR_NOT_ACTIVE = 'not-active';
     const ERROR_NOT_ACTIVE_ACTIVATION_THROTTLED = 'not-active-activation-throttled';
     const ERROR_NOT_REGISTERED = 'not-registered';
@@ -32,6 +33,15 @@ class LoginResponse extends AbstractResponse
      * @var User
      */
     protected $user;
+
+    public static function emailFailed(User $user)
+    {
+        $instance        = new static(FALSE, self::ERROR_EMAIL_VERIFICATION_FAILED);
+        $instance->user  = $user;
+        $instance->email = $user->getEmail();
+
+        return $instance;
+    }
 
     public static function notActive(User $user)
     {


### PR DESCRIPTION
e.g. if they need a password reset but at this moment in time their
email address doesn't pass MX validation.