### PR TITLE
Fix deprecation on password ->isCorrect() when hash is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* Fix deprecation on password ->isCorrect() when hash is null - e.g. if a user's password has never been initialised.
+
 ### v1.2.1 (2022-10-24)
 
 * Checking MX records for valid emails is unreliable and hes been dropped from symfony/validation. Utilise 'strict' mode instead to check the address looks valid.

--- a/src/Support/NativePasswordHasher.php
+++ b/src/Support/NativePasswordHasher.php
@@ -36,6 +36,10 @@ class NativePasswordHasher implements PasswordHasher
 
     public function isCorrect($password, $hash)
     {
+        if ($hash === NULL) {
+            return FALSE;
+        }
+
         return \password_verify($password, $hash);
     }
 

--- a/src/Support/PasswordHasher.php
+++ b/src/Support/PasswordHasher.php
@@ -19,7 +19,7 @@ interface PasswordHasher
 
     /**
      * @param string $password
-     * @param string $hash
+     * @param ?string $hash
      *
      * @return boolean
      */

--- a/test/unit/Support/NativePasswordHasherTest.php
+++ b/test/unit/Support/NativePasswordHasherTest.php
@@ -51,6 +51,13 @@ class NativePasswordHasherTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($expect_correct, $subject->isCorrect($verify_password, $hash));
     }
 
+    public function test_it_can_verify_password_does_not_match_null_hash()
+    {
+        // e.g. if a user account does not have a password yet
+        $subject = $this->newSubject();
+        $this->assertFalse($subject->isCorrect('anything', NULL));
+    }
+
     public function test_it_can_verify_old_hashed_password_even_when_configuration_has_changed()
     {
         $password                        = '12346689';


### PR DESCRIPTION
For example, new users created by some external process may have never set a password, so have a null password hash. In this case any password they provide for checking will be incorrect.